### PR TITLE
Change anvil branche to dev

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 'release*'
-      - anvil
+      - dev
 concurrency:
   group: docker-build-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This one I can't make as a suggestion comment, but having the autobuild on dev is needed for the gitops preview. For anvil we use [fork now](https://github.com/anvilproject/galaxy), so don't need that branch.