### PR TITLE
Release abandoned object-store reads, and cover generic_s3

### DIFF
--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -1,8 +1,14 @@
 import logging
 import os
 import shutil
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import (
+    Callable,
+    Iterator,
+)
+from contextlib import (
+    AbstractContextManager,
+    contextmanager,
+)
 from datetime import datetime
 from typing import Any
 from uuid import uuid4
@@ -29,6 +35,22 @@ log = logging.getLogger(__name__)
 
 # Size of the chunks pulled from the backing store when tee-streaming an object to a client.
 STREAM_CHUNK_SIZE = 1024 * 1024
+
+
+@contextmanager
+def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> Iterator[Iterator[bytes]]:
+    """Pair an open read of a remote object with the call that releases it.
+
+    Backends hand back the SDK's own close rather than leaving it to the chunk iterator, because
+    closing the iterator is not the same thing: botocore's ``iter_chunks`` is a plain generator over
+    ``StreamingBody.read``, so closing it ends the loop but leaves the HTTP response open and its
+    connection out of the pool. Abandoning a read part way is the normal case on this path, not the
+    rare one -- it exists for large downloads, which are the ones clients cancel.
+    """
+    try:
+        yield chunks
+    finally:
+        close()
 
 
 class CachingConcreteObjectStore(ConcreteObjectStore):
@@ -151,9 +173,6 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             # Serve the cached copy instead: it supports range requests and X-Accel offload.
             return None
         try:
-            chunks = self._stream_remote(rel_path)
-            if chunks is None:
-                return None
             remote_size = self._get_remote_size(rel_path)
             if remote_size < 0:
                 # Backends report an unknown size as a negative number. Without it a stream cannot be
@@ -161,17 +180,32 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 return None
             cache_target = self._cache_shards.get_cache_target(object_id)
             write_cache = cache_target.fits_in_cache(remote_size)
+            # Opening the remote read comes last: everything that can decide against streaming has
+            # already decided, so no bail-out below leaves an open connection with no owner.
+            stream = self._stream_remote(rel_path)
+            if stream is None:
+                return None
         except Exception:
             log.exception("Failed to open a remote stream for '%s', falling back to pulling into cache", rel_path)
             return None
-        return self._tee_to_cache(chunks, cache_path, expected_size=remote_size, write_cache=write_cache)
+        return self._tee_to_cache(stream, cache_path, expected_size=remote_size, write_cache=write_cache)
 
-    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
-        """Yield the bytes of the remote object, or None if this backend cannot stream them."""
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+        """Open a read of the remote object, or None if this backend cannot stream it.
+
+        The context manager owns the read: leaving it releases the connection whether the client took
+        every byte, hung up part way, or the stream errored. :func:`closing_stream` builds one from a
+        chunk iterator and the SDK call that releases it.
+        """
         return None
 
     def _tee_to_cache(
-        self, chunks: Iterator[bytes], cache_path: str, *, expected_size: int, write_cache: bool
+        self,
+        stream: AbstractContextManager[Iterator[bytes]],
+        cache_path: str,
+        *,
+        expected_size: int,
+        write_cache: bool,
     ) -> Iterator[bytes]:
         """Yield the remote object's bytes, writing them into the cache on the way past.
 
@@ -181,23 +215,24 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         a short read that raised nothing would otherwise poison the cache. Objects that do not fit
         in the cache are streamed straight through.
         """
-        if not write_cache:
-            yield from chunks
-            return
-        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-        with self._atomic_download(cache_path) as tmp_path:
-            streamed_size = 0
-            with open(tmp_path, "wb") as tmp_file:
-                for chunk in chunks:
-                    tmp_file.write(chunk)
-                    streamed_size += len(chunk)
-                    yield chunk
-            if streamed_size != expected_size:
-                raise OSError(
-                    f"Streaming '{cache_path}' from the object store returned {streamed_size} bytes, "
-                    f"expected {expected_size}"
-                )
-        fix_permissions(self.config, os.path.dirname(cache_path))
+        with stream as chunks:
+            if not write_cache:
+                yield from chunks
+                return
+            os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+            with self._atomic_download(cache_path) as tmp_path:
+                streamed_size = 0
+                with open(tmp_path, "wb") as tmp_file:
+                    for chunk in chunks:
+                        tmp_file.write(chunk)
+                        streamed_size += len(chunk)
+                        yield chunk
+                if streamed_size != expected_size:
+                    raise OSError(
+                        f"Streaming '{cache_path}' from the object store returned {streamed_size} bytes, "
+                        f"expected {expected_size}"
+                    )
+            fix_permissions(self.config, os.path.dirname(cache_path))
 
     def _exists(self, obj, **kwargs) -> bool:
         in_cache = exists_remotely = False

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from collections.abc import (
     Callable,
+    Generator,
     Iterator,
 )
 from contextlib import (
@@ -67,14 +68,10 @@ class RemoteDataStream(AbstractContextManager[Iterator[bytes]]):
             self._close()
 
 
-def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> RemoteDataStream:
-    return RemoteDataStream(chunks, close)
-
-
 class _ClosingIterator(Iterator[bytes]):
     """An iterator whose owner can release resources before the first ``next`` call."""
 
-    def __init__(self, iterator: Iterator[bytes], close: Callable[[], None]) -> None:
+    def __init__(self, iterator: Generator[bytes, None, None], close: Callable[[], None]) -> None:
         self.iterator = iterator
         self._close = close
         self._closed = False
@@ -92,9 +89,9 @@ class _ClosingIterator(Iterator[bytes]):
         if not self._closed:
             self._closed = True
             try:
-                close_iterator = getattr(self.iterator, "close", None)
-                if callable(close_iterator):
-                    close_iterator()
+                # Unwinds the tee: whatever the generator was part way through -- a temp file, the
+                # ``with`` around the remote read -- gets its cleanup run.
+                self.iterator.close()
             finally:
                 self._close()
 
@@ -244,8 +241,8 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         """Open a read of the remote object, or None if this backend cannot stream it.
 
         The context manager owns the read: leaving it releases the connection whether the client took
-        every byte, hung up part way, or the stream errored. :func:`closing_stream` builds one from a
-        chunk iterator and the SDK call that releases it.
+        every byte, hung up part way, or the stream errored: build one from a chunk iterator and the
+        SDK call that releases it.
         """
         return None
 
@@ -256,7 +253,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         *,
         expected_size: int,
         write_cache: bool,
-    ) -> Iterator[bytes]:
+    ) -> Generator[bytes, None, None]:
         """Yield the remote object's bytes, writing them into the cache on the way past.
 
         The cache copy is published atomically once the whole object has been streamed, so a client

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -37,8 +37,7 @@ log = logging.getLogger(__name__)
 STREAM_CHUNK_SIZE = 1024 * 1024
 
 
-@contextmanager
-def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> Iterator[Iterator[bytes]]:
+class RemoteDataStream(AbstractContextManager[Iterator[bytes]]):
     """Pair an open read of a remote object with the call that releases it.
 
     Backends hand back the SDK's own close rather than leaving it to the chunk iterator, because
@@ -47,10 +46,57 @@ def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> Iterat
     connection out of the pool. Abandoning a read part way is the normal case on this path, not the
     rare one -- it exists for large downloads, which are the ones clients cancel.
     """
-    try:
-        yield chunks
-    finally:
-        close()
+
+    def __init__(self, chunks: Iterator[bytes], close: Callable[[], None]) -> None:
+        self.chunks = chunks
+        self._close = close
+        self._closed = False
+
+    def __enter__(self) -> Iterator[bytes]:
+        if self._closed:
+            raise RuntimeError("Cannot consume a closed remote data stream")
+        return self.chunks
+
+    def __exit__(self, *_args: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release the read even if its chunks were never consumed."""
+        if not self._closed:
+            self._closed = True
+            self._close()
+
+
+def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> RemoteDataStream:
+    return RemoteDataStream(chunks, close)
+
+
+class _ClosingIterator(Iterator[bytes]):
+    """An iterator whose owner can release resources before the first ``next`` call."""
+
+    def __init__(self, iterator: Iterator[bytes], close: Callable[[], None]) -> None:
+        self.iterator = iterator
+        self._close = close
+        self._closed = False
+
+    def __next__(self) -> bytes:
+        if self._closed:
+            raise StopIteration
+        try:
+            return next(self.iterator)
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            try:
+                close_iterator = getattr(self.iterator, "close", None)
+                if callable(close_iterator):
+                    close_iterator()
+            finally:
+                self._close()
 
 
 class CachingConcreteObjectStore(ConcreteObjectStore):
@@ -188,9 +234,13 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         except Exception:
             log.exception("Failed to open a remote stream for '%s', falling back to pulling into cache", rel_path)
             return None
-        return self._tee_to_cache(stream, cache_path, expected_size=remote_size, write_cache=write_cache)
+        iterator = self._tee_to_cache(stream, cache_path, expected_size=remote_size, write_cache=write_cache)
+        # The generator above does not enter ``stream`` until its first next() call. Give the
+        # response an explicit close that owns the already-open remote read even if the client goes
+        # away while response headers are being sent and the generator is never started.
+        return _ClosingIterator(iterator, stream.close)
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         """Open a read of the remote object, or None if this backend cannot stream it.
 
         The context manager owns the read: leaving it releases the connection whether the client took
@@ -201,7 +251,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
     def _tee_to_cache(
         self,
-        stream: AbstractContextManager[Iterator[bytes]],
+        stream: RemoteDataStream,
         cache_path: str,
         *,
         expected_size: int,

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -5,6 +5,10 @@ Object Store plugin for the Microsoft Azure Block Blob Storage system
 import logging
 import os
 from collections.abc import Iterator
+from contextlib import (
+    AbstractContextManager,
+    nullcontext,
+)
 from datetime import timedelta
 
 try:
@@ -261,8 +265,10 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
         with open(local_destination, "wb") as f:
             self._blob_client(rel_path).download_blob().download_to_stream(f, **kwd)
 
-    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
-        return self._blob_client(rel_path).download_blob().chunks()
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+        # Nothing to release: the downloader pulls each chunk with its own ranged request rather
+        # than holding one response open, and exposes no close of its own.
+        return nullcontext(self._blob_client(rel_path).download_blob().chunks())
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         blobs = self._blobs_from(rel_path)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -19,7 +19,6 @@ except ImportError:
 from galaxy.util import now
 from ._caching_base import (
     CachingConcreteObjectStore,
-    closing_stream,
     RemoteDataStream,
 )
 from .caching import (
@@ -267,7 +266,7 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
     def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         # Nothing to release: the downloader pulls each chunk with its own ranged request rather
         # than holding one response open, and exposes no close of its own.
-        return closing_stream(self._blob_client(rel_path).download_blob().chunks(), lambda: None)
+        return RemoteDataStream(self._blob_client(rel_path).download_blob().chunks(), lambda: None)
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         blobs = self._blobs_from(rel_path)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -4,11 +4,6 @@ Object Store plugin for the Microsoft Azure Block Blob Storage system
 
 import logging
 import os
-from collections.abc import Iterator
-from contextlib import (
-    AbstractContextManager,
-    nullcontext,
-)
 from datetime import timedelta
 
 try:
@@ -22,7 +17,11 @@ except ImportError:
     BlobServiceClient = None  # type: ignore[assignment,unused-ignore,misc]
 
 from galaxy.util import now
-from ._caching_base import CachingConcreteObjectStore
+from ._caching_base import (
+    CachingConcreteObjectStore,
+    closing_stream,
+    RemoteDataStream,
+)
 from .caching import (
     CacheShardManager,
     CacheTarget,
@@ -265,10 +264,10 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
         with open(local_destination, "wb") as f:
             self._blob_client(rel_path).download_blob().download_to_stream(f, **kwd)
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         # Nothing to release: the downloader pulls each chunk with its own ranged request rather
         # than holding one response open, and exposes no close of its own.
-        return nullcontext(self._blob_client(rel_path).download_blob().chunks())
+        return closing_stream(self._blob_client(rel_path).download_blob().chunks(), lambda: None)
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         blobs = self._blobs_from(rel_path)

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -8,7 +8,6 @@ import os.path
 
 from ._caching_base import (
     CachingConcreteObjectStore,
-    closing_stream,
     RemoteDataStream,
 )
 from ._util import UsesAxel
@@ -272,7 +271,7 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
         # cloudbridge promises an iterable and nothing more, and what it hands back differs per
         # provider -- a wrapper around the S3 body, a swift generator, a BytesIO -- so release it
         # only if it knows how.
-        return closing_stream(iter(content), getattr(content, "close", lambda: None))
+        return RemoteDataStream(iter(content), getattr(content, "close", lambda: None))
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         objects = self.bucket.objects.list(prefix=rel_path)

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -5,12 +5,11 @@ Object Store plugin for Cloud storage.
 import logging
 import os
 import os.path
-from collections.abc import Iterator
-from contextlib import AbstractContextManager
 
 from ._caching_base import (
     CachingConcreteObjectStore,
     closing_stream,
+    RemoteDataStream,
 )
 from ._util import UsesAxel
 from .caching import (
@@ -265,7 +264,7 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self.bucket.name)
         return False
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         key = self.bucket.objects.get(rel_path)
         if key is None:
             return None

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -6,8 +6,12 @@ import logging
 import os
 import os.path
 from collections.abc import Iterator
+from contextlib import AbstractContextManager
 
-from ._caching_base import CachingConcreteObjectStore
+from ._caching_base import (
+    CachingConcreteObjectStore,
+    closing_stream,
+)
 from ._util import UsesAxel
 from .caching import (
     CacheShardManager,
@@ -261,11 +265,15 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self.bucket.name)
         return False
 
-    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
         key = self.bucket.objects.get(rel_path)
         if key is None:
             return None
-        return key.iter_content()
+        content = key.iter_content()
+        # cloudbridge promises an iterable and nothing more, and what it hands back differs per
+        # provider -- a wrapper around the S3 body, a swift generator, a BytesIO -- so release it
+        # only if it knows how.
+        return closing_stream(iter(content), getattr(content, "close", lambda: None))
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         objects = self.bucket.objects.list(prefix=rel_path)

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -19,7 +19,6 @@ except ImportError:
 from galaxy.util import string_as_bool
 from ._caching_base import (
     CachingConcreteObjectStore,
-    closing_stream,
     RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
@@ -339,7 +338,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             return None
         # fast=True: a client that hung up should not make Galaxy read the rest of the object off
         # the wire before the connection can be released.
-        return closing_stream(iter(lambda: key.read(STREAM_CHUNK_SIZE), b""), lambda: key.close(fast=True))
+        return RemoteDataStream(iter(lambda: key.read(STREAM_CHUNK_SIZE), b""), lambda: key.close(fast=True))
 
     def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
         """

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -5,8 +5,6 @@ Object Store plugin for the Amazon Simple Storage Service (S3)
 import logging
 import os
 import time
-from collections.abc import Iterator
-from contextlib import AbstractContextManager
 from datetime import datetime
 
 try:
@@ -22,6 +20,7 @@ from galaxy.util import string_as_bool
 from ._caching_base import (
     CachingConcreteObjectStore,
     closing_stream,
+    RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
 from ._util import UsesAxel
@@ -334,7 +333,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self._bucket.name)
         return False
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         key = self._bucket.get_key(rel_path)
         if key is None:
             return None

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -5,6 +5,8 @@ Object Store plugin for the Amazon Simple Storage Service (S3)
 import logging
 import os
 import time
+from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from datetime import datetime
 
 try:
@@ -17,7 +19,11 @@ except ImportError:
     boto = None  # type: ignore[assignment]
 
 from galaxy.util import string_as_bool
-from ._caching_base import CachingConcreteObjectStore
+from ._caching_base import (
+    CachingConcreteObjectStore,
+    closing_stream,
+    STREAM_CHUNK_SIZE,
+)
 from ._util import UsesAxel
 from .caching import (
     CacheShardManager,
@@ -327,6 +333,14 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
         except S3ResponseError:
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self._bucket.name)
         return False
+
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+        key = self._bucket.get_key(rel_path)
+        if key is None:
+            return None
+        # fast=True: a client that hung up should not make Galaxy read the rest of the object off
+        # the wire before the connection can be released.
+        return closing_stream(iter(lambda: key.read(STREAM_CHUNK_SIZE), b""), lambda: key.close(fast=True))
 
     def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
         """

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -6,6 +6,7 @@ from collections.abc import (
     Callable,
     Iterator,
 )
+from contextlib import AbstractContextManager
 from typing import (
     Any,
     Literal,
@@ -35,6 +36,7 @@ from galaxy.util import asbool
 from galaxy.util.s3_checksum import s3_checksum_config_kwargs
 from ._caching_base import (
     CachingConcreteObjectStore,
+    closing_stream,
     STREAM_CHUNK_SIZE,
 )
 from .caching import (
@@ -342,9 +344,9 @@ class S3ObjectStore(CachingConcreteObjectStore):
             log.exception("Failed to download file from S3")
         return False
 
-    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
         body = self._client.get_object(Bucket=self.bucket, Key=rel_path)["Body"]
-        return body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE)
+        return closing_stream(body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE), body.close)
 
     def _push_string_to_path(self, rel_path: str, from_string: str) -> bool:
         try:

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -32,7 +32,6 @@ from galaxy.util import asbool
 from galaxy.util.s3_checksum import s3_checksum_config_kwargs
 from ._caching_base import (
     CachingConcreteObjectStore,
-    closing_stream,
     RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
@@ -343,7 +342,7 @@ class S3ObjectStore(CachingConcreteObjectStore):
 
     def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         body = self._client.get_object(Bucket=self.bucket, Key=rel_path)["Body"]
-        return closing_stream(body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE), body.close)
+        return RemoteDataStream(body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE), body.close)
 
     def _push_string_to_path(self, rel_path: str, from_string: str) -> bool:
         try:

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -2,11 +2,7 @@
 
 import logging
 import os
-from collections.abc import (
-    Callable,
-    Iterator,
-)
-from contextlib import AbstractContextManager
+from collections.abc import Callable
 from typing import (
     Any,
     Literal,
@@ -37,6 +33,7 @@ from galaxy.util.s3_checksum import s3_checksum_config_kwargs
 from ._caching_base import (
     CachingConcreteObjectStore,
     closing_stream,
+    RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
 from .caching import (
@@ -344,7 +341,7 @@ class S3ObjectStore(CachingConcreteObjectStore):
             log.exception("Failed to download file from S3")
         return False
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         body = self._client.get_object(Bucket=self.bucket, Key=rel_path)["Body"]
         return closing_stream(body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE), body.close)
 

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -251,6 +251,10 @@ class GalaxyStreamingResponse(StreamingResponse):
       lazily loads an ORM relationship, issues a query, or commits, it trips the
       FOOTGUN below.
 
+    RESOURCE OWNERSHIP: If synchronous response content exposes ``close()``,
+      this response calls it after streaming or when response setup/sending
+      fails, including failures before the content's first iteration.
+
     FOOTGUN: the request-id ``ContextVar`` that keys the ``scoped_session`` is
       still set while the body streams (same asyncio task). If body code touches
       ``app.model.session`` after we close it, ``scoped_session`` will SILENTLY
@@ -265,7 +269,15 @@ class GalaxyStreamingResponse(StreamingResponse):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        content = kwargs.get("content", args[0] if args else None)
+        close_content = getattr(content, "close", None)
+        self._close_content = close_content if callable(close_content) else None
+        try:
+            super().__init__(*args, **kwargs)
+        except BaseException:
+            if self._close_content is not None:
+                self._close_content()
+            raise
         # Capture concrete, already-open request-scoped sessions NOW, while we
         # are guaranteed to be in the request's asyncio task (so the request-id
         # ContextVar resolves). We never call the scoped proxy, which would
@@ -274,7 +286,11 @@ class GalaxyStreamingResponse(StreamingResponse):
 
     async def stream_response(self, send: "Send") -> None:
         _release_request_sessions(self._sessions_to_release)
-        await super().stream_response(send)
+        try:
+            await super().stream_response(send)
+        finally:
+            if self._close_content is not None:
+                self._close_content()
 
 
 def add_sentry_middleware(app: FastAPI) -> None:

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -727,9 +727,6 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         is_archive = datatype.is_archive_download(trans.app.datatypes_registry, dataset_instance.extension)
         if not is_direct_download_candidate(filename, to_ext, False, offset, ck_size, is_archive):
             return None
-        stream = trans.app.object_store.get_data_stream(dataset_instance.dataset)
-        if stream is None:
-            return None
         headers = {
             # Force octet-stream so Safari doesn't append mime extensions to the filename.
             "content-type": "application/octet-stream",
@@ -739,6 +736,11 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         if size:
             # Known up front from the store's metadata, so clients still get a progress bar.
             headers["Content-Length"] = str(size)
+        # Opened last so that nothing between here and the response can fail with a read already in
+        # flight: an open stream is only released once something starts consuming it.
+        stream = trans.app.object_store.get_data_stream(dataset_instance.dataset)
+        if stream is None:
+            return None
         trans.log_event(f"Download dataset id: {str(dataset_instance.id)}")
         return stream, headers
 

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -741,7 +741,13 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         stream = trans.app.object_store.get_data_stream(dataset_instance.dataset)
         if stream is None:
             return None
-        trans.log_event(f"Download dataset id: {str(dataset_instance.id)}")
+        try:
+            trans.log_event(f"Download dataset id: {str(dataset_instance.id)}")
+        except BaseException:
+            close_stream = getattr(stream, "close", None)
+            if callable(close_stream):
+                close_stream()
+            raise
         return stream, headers
 
     def display(

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -7,6 +7,7 @@ from tempfile import (
     mkstemp,
 )
 from unittest.mock import (
+    call,
     MagicMock,
     patch,
 )
@@ -20,7 +21,10 @@ from galaxy.objectstore import (
     ObjectStoreAuth,
     persist_extra_files_for_dataset,
 )
-from galaxy.objectstore._caching_base import closing_stream
+from galaxy.objectstore._caching_base import (
+    closing_stream,
+    STREAM_CHUNK_SIZE,
+)
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
 from galaxy.objectstore.caching import (
     CacheTarget,
@@ -1161,6 +1165,34 @@ def test_stream_remote_cloud_reads_object_content_in_chunks():
 
         object_store.bucket.objects.get.assert_called_once_with("000/dataset_1.dat")
         content.close.assert_called_once_with()
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_s3_reads_key_in_chunks():
+    # boto2 backs both aws_s3 and generic_s3; #19255 reports generic_s3 truncating 4GB downloads to
+    # 3GB, which the tee's size check turns into a failure instead of a corrupt file.
+    with TestConfig(S3_TEST_CONFIG_YAML) as (directory, object_store):
+        key = MagicMock()
+        key.read.side_effect = [b"chunk1", b"chunk2", b""]
+        object_store._bucket = MagicMock()
+        object_store._bucket.get_key.return_value = key
+
+        with object_store._stream_remote("000/dataset_1.dat") as chunks:
+            assert list(chunks) == [b"chunk1", b"chunk2"]
+
+        object_store._bucket.get_key.assert_called_once_with("000/dataset_1.dat")
+        assert key.read.call_args_list == [call(STREAM_CHUNK_SIZE)] * 3
+        # fast=True, or releasing an abandoned key would first read the rest of the object.
+        key.close.assert_called_once_with(fast=True)
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_s3_returns_none_for_a_missing_key():
+    with TestConfig(S3_TEST_CONFIG_YAML) as (directory, object_store):
+        object_store._bucket = MagicMock()
+        object_store._bucket.get_key.return_value = None
+
+        assert object_store._stream_remote("000/dataset_1.dat") is None
 
 
 @patch_object_stores_to_skip_initialize

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -20,6 +20,7 @@ from galaxy.objectstore import (
     ObjectStoreAuth,
     persist_extra_files_for_dataset,
 )
+from galaxy.objectstore._caching_base import closing_stream
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
 from galaxy.objectstore.caching import (
     CacheTarget,
@@ -823,12 +824,17 @@ def _leftover_temp_files(cache_path):
     return [name for name in os.listdir(cache_dir) if name.endswith(".tmp")]
 
 
+def _remote_stream(chunks, on_close=None):
+    """Build what `_stream_remote` returns: an open read, plus the call that releases it."""
+    return closing_stream(iter(chunks), on_close or (lambda: None))
+
+
 @patch_object_stores_to_skip_initialize
 def test_get_data_stream_tees_remote_bytes_into_cache():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         dataset = MockDataset(1)
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream([b"chunk1", b"chunk2"])),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -846,7 +852,7 @@ def test_get_data_stream_discards_partial_cache_when_client_disconnects():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         dataset = MockDataset(1)
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream([b"chunk1", b"chunk2"])),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -870,7 +876,7 @@ def test_get_data_stream_discards_partial_cache_when_remote_read_fails():
             raise OSError("connection reset by the object store")
 
         with (
-            patch.object(object_store, "_stream_remote", return_value=failing_chunks()),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream(failing_chunks())),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -889,7 +895,7 @@ def test_get_data_stream_bypasses_cache_when_object_is_bigger_than_cache():
         dataset = MockDataset(1)
         one_terabyte = 1024**4
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream([b"chunk1", b"chunk2"])),
             patch.object(object_store, "_get_remote_size", return_value=one_terabyte),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -907,7 +913,7 @@ def test_get_data_stream_does_not_cache_a_truncated_object():
         dataset = MockDataset(1)
         # The store says the object is 12 bytes but the stream ends after 6.
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1"])),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream([b"chunk1"])),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -927,10 +933,90 @@ def test_get_data_stream_returns_none_when_remote_size_is_unknown():
         # Backends report an unknown size as a negative number; without a size there is nothing to
         # check a streamed object against, so fall back to pulling it into the cache.
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1"])),
+            patch.object(object_store, "_stream_remote") as stream_remote,
             patch.object(object_store, "_get_remote_size", return_value=-1),
         ):
             assert object_store.get_data_stream(MockDataset(1)) is None
+            # Deciding against streaming after opening the read would strand the connection: nobody
+            # owns it once None is returned in its place.
+            stream_remote.assert_not_called()
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_does_not_open_a_read_it_cannot_hand_over():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        # Same reason, for the other way the decision can go wrong: a size lookup that raises.
+        with (
+            patch.object(object_store, "_stream_remote") as stream_remote,
+            patch.object(object_store, "_get_remote_size", side_effect=OSError("no such key")),
+        ):
+            assert object_store.get_data_stream(MockDataset(1)) is None
+            stream_remote.assert_not_called()
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_releases_the_remote_read_when_the_client_disconnects():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        closed = []
+        with (
+            patch.object(
+                object_store,
+                "_stream_remote",
+                return_value=_remote_stream([b"chunk1", b"chunk2"], on_close=lambda: closed.append(True)),
+            ),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(MockDataset(1))
+            assert stream is not None
+            assert next(stream) == b"chunk1"
+            stream.close()
+            # An abandoned read has to hand its connection back, or a cancelled download costs one
+            # from the pool for as long as the store keeps the response open.
+            assert closed == [True]
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_releases_the_remote_read_when_it_errors():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        closed = []
+
+        def failing_chunks():
+            yield b"chunk1"
+            raise OSError("connection reset by the object store")
+
+        with (
+            patch.object(
+                object_store,
+                "_stream_remote",
+                return_value=_remote_stream(failing_chunks(), on_close=lambda: closed.append(True)),
+            ),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(MockDataset(1))
+            assert stream is not None
+            with pytest.raises(OSError):
+                b"".join(stream)
+            assert closed == [True]
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_releases_the_remote_read_when_it_is_not_cached():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        closed = []
+        one_terabyte = 1024**4
+        with (
+            patch.object(
+                object_store,
+                "_stream_remote",
+                return_value=_remote_stream([b"chunk1", b"chunk2"], on_close=lambda: closed.append(True)),
+            ),
+            patch.object(object_store, "_get_remote_size", return_value=one_terabyte),
+        ):
+            stream = object_store.get_data_stream(MockDataset(1))
+            assert stream is not None
+            # The bigger-than-cache path skips the tee entirely; it still owns the read.
+            assert b"".join(stream) == b"chunk1chunk2"
+            assert closed == [True]
 
 
 @patch_object_stores_to_skip_initialize
@@ -973,7 +1059,9 @@ def test_get_data_stream_concurrent_streams_do_not_corrupt_cache():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         dataset = MockDataset(1)
         with (
-            patch.object(object_store, "_stream_remote", side_effect=lambda rel_path: iter([b"chunk1", b"chunk2"])),
+            patch.object(
+                object_store, "_stream_remote", side_effect=lambda rel_path: _remote_stream([b"chunk1", b"chunk2"])
+            ),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             first = object_store.get_data_stream(dataset)
@@ -1021,12 +1109,29 @@ def test_stream_remote_boto3_reads_object_body_in_chunks():
         object_store._client = MagicMock()
         object_store._client.get_object.return_value = {"Body": body}
 
-        chunks = object_store._stream_remote("000/dataset_1.dat")
+        with object_store._stream_remote("000/dataset_1.dat") as chunks:
+            assert list(chunks) == [b"chunk1", b"chunk2"]
 
-        assert list(chunks) == [b"chunk1", b"chunk2"]
         _, call_kwargs = object_store._client.get_object.call_args
         assert call_kwargs["Bucket"] == object_store.bucket
         assert call_kwargs["Key"] == "000/dataset_1.dat"
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_boto3_closes_the_response_body_not_just_the_chunk_iterator():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        body = MagicMock()
+        # botocore builds iter_chunks as a plain generator over StreamingBody.read, so closing it
+        # ends the loop and leaves the response -- and its pooled connection -- open.
+        body.iter_chunks.return_value = iter([b"chunk1", b"chunk2"])
+        object_store._client = MagicMock()
+        object_store._client.get_object.return_value = {"Body": body}
+
+        with object_store._stream_remote("000/dataset_1.dat") as chunks:
+            assert next(chunks) == b"chunk1"
+            body.close.assert_not_called()
+
+        body.close.assert_called_once_with()
 
 
 @patch_object_stores_to_skip_initialize
@@ -1035,9 +1140,9 @@ def test_stream_remote_azure_reads_blob_in_chunks():
         blob_client = MagicMock()
         blob_client.download_blob.return_value.chunks.return_value = iter([b"chunk1", b"chunk2"])
         with patch.object(object_store, "_blob_client", return_value=blob_client) as blob_client_for:
-            chunks = object_store._stream_remote("000/dataset_1.dat")
+            with object_store._stream_remote("000/dataset_1.dat") as chunks:
+                assert list(chunks) == [b"chunk1", b"chunk2"]
 
-            assert list(chunks) == [b"chunk1", b"chunk2"]
             blob_client_for.assert_called_once_with("000/dataset_1.dat")
 
 
@@ -1045,14 +1150,17 @@ def test_stream_remote_azure_reads_blob_in_chunks():
 def test_stream_remote_cloud_reads_object_content_in_chunks():
     with TestConfig(get_example("cloud_aws_simple.yml")) as (directory, object_store):
         key = MagicMock()
-        key.iter_content.return_value = iter([b"chunk1", b"chunk2"])
+        content = MagicMock()
+        content.__iter__.return_value = iter([b"chunk1", b"chunk2"])
+        key.iter_content.return_value = content
         object_store.bucket = MagicMock()
         object_store.bucket.objects.get.return_value = key
 
-        chunks = object_store._stream_remote("000/dataset_1.dat")
+        with object_store._stream_remote("000/dataset_1.dat") as chunks:
+            assert list(chunks) == [b"chunk1", b"chunk2"]
 
-        assert list(chunks) == [b"chunk1", b"chunk2"]
         object_store.bucket.objects.get.assert_called_once_with("000/dataset_1.dat")
+        content.close.assert_called_once_with()
 
 
 @patch_object_stores_to_skip_initialize

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -980,6 +980,26 @@ def test_get_data_stream_releases_the_remote_read_when_the_client_disconnects():
 
 
 @patch_object_stores_to_skip_initialize
+def test_get_data_stream_releases_the_remote_read_before_the_first_chunk():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        closed = []
+        with (
+            patch.object(
+                object_store,
+                "_stream_remote",
+                return_value=_remote_stream([b"chunk1", b"chunk2"], on_close=lambda: closed.append(True)),
+            ),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(MockDataset(1))
+            assert stream is not None
+            stream.close()
+            # A client can disappear while response headers are being sent, before Starlette asks
+            # the iterator for its first chunk. The already-open read must still be released.
+            assert closed == [True]
+
+
+@patch_object_stores_to_skip_initialize
 def test_get_data_stream_releases_the_remote_read_when_it_errors():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         closed = []

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -22,7 +22,7 @@ from galaxy.objectstore import (
     persist_extra_files_for_dataset,
 )
 from galaxy.objectstore._caching_base import (
-    closing_stream,
+    RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
@@ -830,7 +830,7 @@ def _leftover_temp_files(cache_path):
 
 def _remote_stream(chunks, on_close=None):
     """Build what `_stream_remote` returns: an open read, plus the call that releases it."""
-    return closing_stream(iter(chunks), on_close or (lambda: None))
+    return RemoteDataStream(iter(chunks), on_close or (lambda: None))
 
 
 @patch_object_stores_to_skip_initialize

--- a/test/unit/webapps/galaxy/services/test_datasets_service.py
+++ b/test/unit/webapps/galaxy/services/test_datasets_service.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from galaxy.exceptions import InternalServerError
 from galaxy.webapps.galaxy.services.datasets import (
     DatasetsService,
     is_direct_download_candidate,
@@ -68,6 +69,27 @@ def test_display_streams_whole_file_download_from_object_store():
     assert headers["Content-Length"] == "7"
     # A forward-only stream cannot answer range requests, so it must not claim it can.
     assert "accept-ranges" not in headers
+
+
+def test_display_closes_object_store_stream_when_logging_fails():
+    class ClosableBody:
+        def __init__(self):
+            self.closed = False
+
+        def __iter__(self):
+            return iter([b"data"])
+
+        def close(self):
+            self.closed = True
+
+    body = ClosableBody()
+    service, trans, _ = _service_for_display(data_stream=body)
+    trans.log_event.side_effect = RuntimeError("could not log download")
+
+    with pytest.raises(InternalServerError):
+        service.display(trans, 1, to_ext="txt", allow_stream=True)
+
+    assert body.closed is True
 
 
 def test_display_omits_content_length_when_object_store_size_is_unknown():

--- a/test/unit/webapps/test_streaming_response.py
+++ b/test/unit/webapps/test_streaming_response.py
@@ -10,6 +10,10 @@ objects, and assert the sessions are closed *before* the first body byte.
 
 from types import SimpleNamespace
 
+import pytest
+from starlette.requests import ClientDisconnect
+from starlette.responses import StreamingResponse
+
 from galaxy.webapps.base.api import (
     GalaxyFileResponse,
     GalaxyStreamingResponse,
@@ -118,6 +122,59 @@ async def test_streaming_no_app_bound_is_noop(monkeypatch):
     messages: list = []
     await response.stream_response(await _collect(messages))
     assert any(m["type"] == "http.response.body" for m in messages)
+
+
+async def test_streaming_closes_sync_body_when_client_disconnects_before_first_chunk(monkeypatch):
+    _install_fake_app(monkeypatch, app_present=False)
+
+    class ClosableBody:
+        def __init__(self):
+            self.closed = False
+
+        def __iter__(self):
+            return iter([b"data"])
+
+        def close(self):
+            self.closed = True
+
+    body = ClosableBody()
+    response = GalaxyStreamingResponse(body)
+
+    async def send(_message):
+        # ASGI 2.4 reports a disconnect as an OSError from send. This happens while Starlette is
+        # sending http.response.start, before it advances the synchronous body iterator.
+        raise OSError("client disconnected")
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    with pytest.raises(ClientDisconnect):
+        await response({"type": "http", "method": "GET", "asgi": {"spec_version": "2.4"}}, receive, send)
+
+    assert body.closed is True
+
+
+def test_streaming_closes_sync_body_when_response_construction_fails(monkeypatch):
+    class ClosableBody:
+        def __init__(self):
+            self.closed = False
+
+        def __iter__(self):
+            return iter([b"data"])
+
+        def close(self):
+            self.closed = True
+
+    body = ClosableBody()
+
+    def fail_to_construct(*_args, **_kwargs):
+        raise RuntimeError("could not construct response")
+
+    monkeypatch.setattr(StreamingResponse, "__init__", fail_to_construct)
+    with pytest.raises(RuntimeError, match="could not construct response"):
+        GalaxyStreamingResponse(body)
+
+    assert body.closed is True
 
 
 async def test_file_response_releases_before_response_start(monkeypatch, tmp_path):


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of jmchilton.** They reviewed #23321 and asked me to implement the two blocking findings as code rather than leave them as comments. Words below are mine, not theirs.

Follow-ups to a review of #23321, based on `objectstore-tee-streaming` rather than `dev` so it can merge into that branch before it lands. Two findings, plus the fallout from fixing the second properly.

## `generic_s3` gets a `_stream_remote`

#19255 reports three backends. Two are `type: boto3` and #23321 already fixes them. The third is `generic_s3`, and it is the one the reporter calls unusable — 4GB+ downloads succeed but arrive silently truncated to about 3GB.

`generic_s3` is `GenericS3ObjectStore`, which extends the **boto2** `s3.S3ObjectStore` — a different class from the boto3 `s3_boto3.S3ObjectStore` that got the override — so it inherited the no-op and kept pulling into the cache. It is also the case this machinery handles best: `_tee_to_cache` compares streamed bytes against the store's size, turning a silent truncation into a loud `OSError` instead of a corrupt cached object.

The override goes on the boto2 `S3ObjectStore`, so `aws_s3` (boto2) gets it too. Two details worth a look:

- boto2's `Key.read(size)` opens the GET lazily and returns `b""` at EOF, so `iter(lambda: key.read(STREAM_CHUNK_SIZE), b"")` is the natural chunk iterator and it honours the shared constant.
- `Key.close()` **reads the rest of the response** before releasing unless told not to, which on an abandoned 4GB download is exactly backwards — hence `fast=True`.

## Abandoned streams release their connection

`_stream_remote` returned a bare `Iterator[bytes]`, which has no way to release what it is reading from. The tempting cheap fix — `finally: getattr(chunks, "close", ...)()` — is actively wrong here, and reading botocore is what settled it. `StreamingBody.iter_chunks` is a plain generator over `self.read(chunk_size)` (`botocore/response.py:165`), so it *does* have a `.close()`: the generator's. Calling it ends the loop and leaves `_raw_stream` open and the connection out of the pool. The thing that must be closed is `StreamingBody.close()` (`:190`), which the chunk iterator gives no access to. A `getattr`-based fix would have looked like it worked and leaked anyway.

So backends now return a `RemoteDataStream` pairing the chunks with the SDK's own close, and `_tee_to_cache` enters it. Per backend:

- `s3_boto3` — `body.close`.
- `cloud` — cloudbridge's `iter_content()` promises `Iterable[bytes]` and nothing more, and the concrete type differs per provider (an AWS wrapper around the boto3 body with its own `close`, an OpenStack swift generator, a GCP `BytesIO`). Closed only if it knows how.
- `azure_blob` — **nothing to close, and this is the one claim I could not verify.** `StorageStreamDownloader` exposes no `close`, and `chunks()` appears to pull each chunk with its own ranged request rather than holding one response open. That is from the SDK's documented shape; I had no azure-storage-blob install to check against. Please confirm.

Ordering matters too: `_get_data_stream` and `_stream_from_object_store` both used to open the read *first* and could then decide against streaming — unknown remote size, a size lookup that raised — returning `None` with a live read nobody owned. The open is now the last fallible step in both.

One cost of that reorder, stated rather than buried: `object_store.size()` in `_stream_from_object_store` now runs before we know streaming applies. Disk stores pay a `stat`; caching stores with no `_stream_remote` (irods, pithos, onedata, rucio) pay the remote size lookup immediately before pulling the whole object into cache anyway. Judged negligible, but it is a real change.

## Closing before the first chunk

A generator does not enter its `with` until the first `next()`, so a failure between `get_data_stream()` returning and the ASGI server consuming the body still left the read to GC. Three complementary pieces — the first gives the iterator a meaningful `close()`, the other two make sure something calls it:

- `RemoteDataStream.close()` is idempotent and works whether or not the manager was entered.
- `_get_data_stream` wraps the tee generator in `_ClosingIterator`, whose `close()` unwinds the generator *and* the stream.
- `GalaxyStreamingResponse` closes sync response content on completion, on send failure, and on `__init__` failure; `_stream_from_object_store` closes if `trans.log_event` raises.

**Flagging the blast radius, because it is wider than this feature:** `GalaxyStreamingResponse` now closes *any* sync content exposing `close()`, which is every streaming endpoint in Galaxy. I walked the callers and found nothing broken — the SSE endpoints (`api/events.py`, `api/plugins.py`) pass async generators, which expose `aclose` not `close`, so they are untouched; the `BytesIO`/`StringIO` cases (page PDFs, invocation report PDFs, `serve_workbook`, datasets) are locally built buffers nothing reads afterwards; and the sync generators (`util/zipstream.py:response` behind three `history_contents` archive routes, `api/proxy.py:stream_with_cleanup`) are either exhausted by then or benefit from having their `finally` run. Still, it deserves a second pair of eyes rather than being left to be discovered.

There is one race I chased and cleared: `stream_response`'s `finally` could in principle close the tee generator while a threadpool `next()` is still running it. It cannot, because Starlette's `iterate_in_threadpool` uses `anyio.to_thread.run_sync` without `abandon_on_cancel`, so cancellation waits for the in-flight `next()` to return. That is reasoned from anyio's semantics, not observed.

## Verification

- `test/unit/objectstore/` and `test/unit/webapps/` → **182 passed, 12 skipped**.
- Eight new unit tests, each failing before its commit. Red-to-green confirmed concretely on the `generic_s3` half: reverting `s3.py` alone makes `test_stream_remote_s3_reads_key_in_chunks` fail.
- Coverage added for both ways the old ordering stranded an open read, for release on client disconnect / stream error / the bigger-than-cache path that skips the tee, for boto3 closing the response *body* rather than just the chunk iterator, and for the two pre-first-chunk paths in `GalaxyStreamingResponse`.
- `ruff` and `flake8` clean; full pre-commit hook set green on every commit.
- `mypy` on all seven changed `lib/` files plus the three test files: 11 errors, none in anything this branch touches. I A/B'd the one that looked new by reverting `s3.py` to this branch's base and re-running — identical 11, same line. It is missing-stub noise from the venv.
- **Not run:** `test/integration/objectstore/test_tee_streaming.py` (docker/minio), and no live S3/Azure/cloudbridge backend. Connection release is pinned against mocks, not observed against a real store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
